### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,6 @@ with open('search_results.json', 'w', encoding='utf-8') as f:
 ```
 
 ### Retrieving Details for Listings
-#### Retrieve Prices, Availability, Reviews, and Host Information
-
-```python
-import pyairbnb
-import json
-room_url="https://www.airbnb.com/rooms/30931885"
-data = pyairbnb.get_reviews(room_url,"")
-with open('reviews.json', 'w', encoding='utf-8') as f:
-    f.write(json.dumps(data["reviews"]))
-```
 
 ### Getting price
 ```python

--- a/src/pyairbnb/standardize.py
+++ b/src/pyairbnb/standardize.py
@@ -152,6 +152,9 @@ def from_details(meta):
         "highlights":[],
     }
 
+    gf = meta["data"]["presentation"]["stayProductDetailPage"]["sections"]["sections"][2]["section"]
+    data["is_guest_favorite"] = utils.get_nested_value(gf,"isGuestFavorite",False)
+
     sd = utils.get_nested_value(meta,"data.presentation.stayProductDetailPage.sections.sbuiData")
     for section in utils.get_nested_value(sd,"sectionConfiguration.root.sections",[]):
         typeName=utils.get_nested_value(section,"sectionData.__typename","")


### PR DESCRIPTION
PURPOSE: Improve readme documentation for new users
ACTION: Removed first example entitled "Retrieve Prices, Availability, Reviews, and Host Information'"
REASON: 
Incorrect Description: Example description (even if it worked) is overly broad; the example only retrieves reviews (not prices, availability, etc.)
Erroneous: The deleted example code generates a TypeError: list indices must be integers or slices, not str. Error is the last line of example to json.dumps the "reviews" portion of the dictionary instead of whole dictionary
Duplicative: A working example of code to obtain reviews is already present as the second to last example