### PR TITLE
Add optional argument for number of adults in price search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 
-version = '0.0.10'
+version = '0.0.11'
 name="pyairbnb"
 description = 'Airbnb scraper in Python'
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = '0.0.10'
+VERSION = '0.0.11'
 DESCRIPTION = 'Airbnb scraper in Python'
 
 setup(

--- a/src/pyairbnb/price.py
+++ b/src/pyairbnb/price.py
@@ -4,7 +4,7 @@ import pyairbnb.utils as utils
 from urllib.parse import urlencode
 ep = "https://www.airbnb.com/api/v3/StaysPdpSections/80c7889b4b0027d99ffea830f6c0d4911a6e863a957cbe1044823f0fc746bf1f"
 
-def get(product_id: str, impresion_id: str,api_key: str, currency: str, cookies: list, checkIn: str, checkOut: str, proxy_url: str) -> (str):
+def get(product_id: str, impresion_id: str,api_key: str, currency: str, cookies: list, checkIn: str, checkOut: str, proxy_url: str, adults: int=1) -> (str):
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
@@ -21,7 +21,7 @@ def get(product_id: str, impresion_id: str,api_key: str, currency: str, cookies:
         variablesData={
             "id": product_id,
             "pdpSectionsRequest": {
-                "adults": "1",
+                "adults":                       str(adults),
                 "bypassTargetings":              False,
                 "categoryTag":                   None,
                 "causeId":                       None,


### PR DESCRIPTION
PROBLEM: Unable to obtain pricing for more than one adult using pyairbnb

SOLUTION: Add optional argument titled "adults" as int which gets cast as string to ensure continuity with existing sections request (i.e. it asks for "1" instead of just 1). The default value remains 1 if no argument is passed. Argument was appended to end so as not to potentially mess up any existing code people have written that send arguments in specific order (vs. explicitly stating the respective argument)

CAVEAT: I do not know how the pricing will come out if there are extra guest fees. From examining the raw json in chrome as a website visitor, there is a line field for extra guest fee so it is something that I plan to introduce in a following PR once this is merged so I can test. Either ways, merging this PR isn't likely to break anything as all I've added is capability to specify number of guests as optional argument.