### PR TITLE
Add back default values for certain fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 
-version = '1.0.3'
+version = '1.0.4'
 name="pyairbnb"
 description = 'Airbnb scraper in Python'
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = '1.0.3'
+VERSION = '1.0.4'
 DESCRIPTION = 'Airbnb scraper in Python'
 
 setup(

--- a/src/pyairbnb/start.py
+++ b/src/pyairbnb/start.py
@@ -49,7 +49,7 @@ def get_reviews(room_url: str ,language: str = "en", proxy_url: str = ""):
 
     return reviews.get(api_key, product_id, "USD", language, proxy_url)
 
-def get_details(room_url: str = None, room_id: int = None, domain: str = "www.airbnb.com", check_in: str = None, check_out: str = None, adults: int = 1, currency: str = "USD", language: str = "en", proxy_url: str = None):
+def get_details(room_url: str = None, room_id: int = None, domain: str = "www.airbnb.com", check_in: str = None, check_out: str = None, adults: int = 1, currency: str = "USD", language: str = "en", proxy_url: str = ""):
     """
     Retrieves all details (calendar, reviews, price, and host details) for a specified room.
 
@@ -101,7 +101,7 @@ def get_details(room_url: str = None, room_id: int = None, domain: str = "www.ai
     return data
 
 def search_all(check_in: str, check_out: str, ne_lat: float, ne_long: float, sw_lat: float, sw_long: float,
-               zoom_value: int, currency: str, place_type: str, price_min: int, price_max: int, amenities: list, language: str, proxy_url: str):
+               zoom_value: int, price_min: int, price_max: int, place_type: str = "", amenities: list = [], currency: str = "USD", language: str = "en", proxy_url: str = ""):
     """
     Performs a paginated search for all rooms within specified geographic bounds.
 
@@ -137,7 +137,7 @@ def search_all(check_in: str, check_out: str, ne_lat: float, ne_long: float, sw_
     return all_results
 
 def search_first_page(check_in: str, check_out: str, ne_lat: float, ne_long: float, sw_lat: float, sw_long: float,
-               zoom_value: int, currency: str, place_type: str, price_min: int, price_max: int, amenities: list, language: str, proxy_url: str):
+               zoom_value: int, price_min: int, price_max: int, place_type: str = "", amenities: list = [], currency: str = "USD", language: str = "en", proxy_url: str = ""):
     """
     Searches the first page of results within specified geographic bounds.
 


### PR DESCRIPTION
proxy_url - folks might not want to use them and it wasn't a required argument before; I did change one from None to "" for consistency's sake language - "en" was the default before
currency - I don't believe there was a default before suffice to say that "USD" is likely to be the most common currency users will want amenities - I don't believe there was a default before, but keeping it an empty list will help with keeping library easy to onboard, especially for quick runs place_type - same reasoning as before

There is some minor rearrangement of arguments so certain fields can now have default values, but given the recent changes, now seemed as good a time as any to "rip off the bandaid".

Thanks as always for putting this library together