### PR TITLE
Dynamic StaysSearch operationId

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,17 @@ import json
 # Define an Airbnb search URL using only the supported parameters (including free cancellation)
 url = "https://www.airbnb.com/s/Luxembourg--Luxembourg/homes?checkin=2026-02-09&checkout=2026-02-16&ne_lat=49.76537&ne_lng=6.56057&sw_lat=49.31155&sw_lng=6.03263&zoom=10&price_min=154&price_max=700&room_types%5B%5D=Entire%20home%2Fapt&amenities%5B%5D=4&amenities%5B%5D=5&flexible_cancellation=true"
 
+# Fetches the live StaysSearch hash first so
+# the persisted query id matches airbnb website.
+dynamic_hash = pyairbnb.fetch_stays_search_hash()
 # Use the URL wrapper
-results = pyairbnb.search_all_from_url(url, currency="EUR", language ="es", proxy_url="")
+results = pyairbnb.search_all_from_url(
+    url,
+    currency="EUR",
+    language="es",
+    proxy_url="",
+    hash=dynamic_hash, # optional, fallbacks to predefined hash
+)
 
 # Save results and print count
 with open('search_from_url.json', 'w', encoding='utf-8') as f:

--- a/src/pyairbnb/__init__.py
+++ b/src/pyairbnb/__init__.py
@@ -2,7 +2,7 @@ from pyairbnb.utils import parse_proxy,get_nested_value
 from pyairbnb.api import get as get_api_key
 from pyairbnb.host import get_listings_from_user
 from pyairbnb.experience import search_by_place_id as experience_search_by_place_id
-from pyairbnb.search import get_markets,get_places_ids
+from pyairbnb.search import get_markets,get_places_ids,fetch_stays_search_hash
 from pyairbnb.start import get_calendar,search_all,search_all_from_url,search_first_page,get_reviews,get_details
 from pyairbnb.start import search_experience_by_taking_the_first_inputs_i_dont_care as experience_search
 from pyairbnb.details import get as get_metadata_from_url

--- a/src/pyairbnb/search.py
+++ b/src/pyairbnb/search.py
@@ -32,8 +32,11 @@ headers_global = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 }
 
-def get(api_key:str, cursor:str, check_in:str, check_out:str, ne_lat:float, ne_long:float, sw_lat:float, sw_long:float, zoom_value:int, currency:str, place_type: str, price_min: int, price_max: int, amenities: list, free_cancellation: bool, language: str, proxy_url:str):
-    base_url = "https://www.airbnb.com/api/v3/StaysSearch/9f945886dcc032b9ef4ba770d9132eb0aa78053296b5405483944c229617b00b"
+def get(api_key:str, cursor:str, check_in:str, check_out:str, ne_lat:float, ne_long:float, sw_lat:float, sw_long:float, zoom_value:int, currency:str, place_type: str, price_min: int, price_max: int, amenities: list, free_cancellation: bool, language: str, proxy_url:str, hash:str):
+    
+    operationId = hash if hash else '9f945886dcc032b9ef4ba770d9132eb0aa78053296b5405483944c229617b00b'
+    base_url = f"https://www.airbnb.com/api/v3/StaysSearch/{operationId}"
+
     query_params = {
         "operationName": "StaysSearch",
         "locale": language,
@@ -105,7 +108,7 @@ def get(api_key:str, cursor:str, check_in:str, check_out:str, ne_lat:float, ne_l
         "extensions":{
             "persistedQuery": {
                 "version": 1,
-                "sha256Hash": "9f945886dcc032b9ef4ba770d9132eb0aa78053296b5405483944c229617b00b",
+                "sha256Hash": operationId,
             },
         },
         "variables":{

--- a/src/pyairbnb/search.py
+++ b/src/pyairbnb/search.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from urllib.parse import urlencode
 import pyairbnb.utils as utils
 from curl_cffi import requests
+import re
 
 ep_autocomplete = "https://www.airbnb.com/api/v2/autocompletes-personalized"
 ep_market = "https://www.airbnb.com/api/v2/user_markets"
@@ -31,6 +32,45 @@ headers_global = {
     "Upgrade-Insecure-Requests": "1",
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 }
+
+def fetch_stays_search_hash(proxy_url: str = "") -> str:
+    proxies = {"http": proxy_url, "https": proxy_url} if proxy_url else None
+    headers = {"User-Agent": headers_global["User-Agent"]}
+
+    homepage = requests.get(
+        "https://www.airbnb.com/",
+        headers=headers,
+        proxies=proxies,
+        impersonate="chrome124",
+    )
+    homepage.raise_for_status()
+
+    bundle_match = re.compile(
+        r"https://a0\.muscache\.com/airbnb/static/packages/web/en/frontend/airmetro/browser/asyncRequire\.[^\"']+\.js"
+    ).search(homepage.text)
+    if not bundle_match:
+        raise RuntimeError("Unable to locate StaysSearch bundle")
+
+    bundle = requests.get(
+        bundle_match.group(0), headers=headers, proxies=proxies, impersonate="chrome124"
+    )
+    bundle.raise_for_status()
+
+    module_match = re.compile(
+        r"common/frontend/stays-search/routes/StaysSearchRoute/StaysSearchRoute\.prepare\.[^\"']+\.js"
+    ).search(bundle.text)
+    if not module_match:
+        raise RuntimeError("Unable to locate StaysSearchRoute module")
+
+    module_url = f"https://a0.muscache.com/airbnb/static/packages/web/{module_match.group(0)}"
+    module = requests.get(module_url, headers=headers, proxies=proxies, impersonate="chrome124")
+    module.raise_for_status()
+
+    hash_match = re.compile(r"operationId:['\"]([0-9a-f]{64})").search(module.text)
+    if not hash_match:
+        raise RuntimeError("Unable to extract StaysSearch operationId")
+
+    return hash_match.group(1)
 
 def get(api_key:str, cursor:str, check_in:str, check_out:str, ne_lat:float, ne_long:float, sw_lat:float, sw_long:float, zoom_value:int, currency:str, place_type: str, price_min: int, price_max: int, amenities: list, free_cancellation: bool, language: str, proxy_url:str, hash:str):
     
@@ -115,6 +155,7 @@ def get(api_key:str, cursor:str, check_in:str, check_out:str, ne_lat:float, ne_l
             "skipExtendedSearchParams": False,
             "includeMapResults": True,
             "isLeanTreatment": False,
+            "aiSearchEnabled": False, # required for dynamic StaysSearch hash
             "staysMapSearchRequestV2": {
                 "cursor":cursor,
                 "requestedPageType":"STAYS_SEARCH",

--- a/src/pyairbnb/start.py
+++ b/src/pyairbnb/start.py
@@ -101,7 +101,7 @@ def get_details(room_url: str = None, room_id: int = None, domain: str = "www.ai
     return data
 
 def search_all(check_in: str, check_out: str, ne_lat: float, ne_long: float, sw_lat: float, sw_long: float,
-               zoom_value: int, price_min: int, price_max: int, place_type: str = "", amenities: list = [], free_cancellation: bool = False, currency: str = "USD", language: str = "en", proxy_url: str = ""):
+               zoom_value: int, price_min: int, price_max: int, place_type: str = "", amenities: list = [], free_cancellation: bool = False, currency: str = "USD", language: str = "en", proxy_url: str = "", hash: str = ""):
     """
     Performs a paginated search for all rooms within specified geographic bounds.
 
@@ -128,7 +128,7 @@ def search_all(check_in: str, check_out: str, ne_lat: float, ne_long: float, sw_
     while True:
         results_raw = search.get(
             api_key, cursor, check_in, check_out, ne_lat, ne_long, sw_lat, sw_long, zoom_value, 
-            currency, place_type, price_min, price_max, amenities, free_cancellation, language, proxy_url
+            currency, place_type, price_min, price_max, amenities, free_cancellation, language, proxy_url, hash
         )
         paginationInfo = utils.get_nested_value(results_raw,"data.presentation.staysSearch.results.paginationInfo",{})
         results = standardize.from_search(results_raw)
@@ -139,7 +139,7 @@ def search_all(check_in: str, check_out: str, ne_lat: float, ne_long: float, sw_
     return all_results
 
 def search_first_page(check_in: str, check_out: str, ne_lat: float, ne_long: float, sw_lat: float, sw_long: float,
-               zoom_value: int, price_min: int, price_max: int, place_type: str = "", amenities: list = [], free_cancellation: bool = False, currency: str = "USD", language: str = "en", proxy_url: str = ""):
+               zoom_value: int, price_min: int, price_max: int, place_type: str = "", amenities: list = [], free_cancellation: bool = False, currency: str = "USD", language: str = "en", proxy_url: str = "", hash: str = ""):
     """
     Searches the first page of results within specified geographic bounds.
 
@@ -162,8 +162,8 @@ def search_first_page(check_in: str, check_out: str, ne_lat: float, ne_long: flo
     """
     api_key = api.get(proxy_url)
     results_raw = search.get(
-            api_key, "", check_in, check_out, ne_lat, ne_long, sw_lat, sw_long, zoom_value, 
-            currency, place_type, price_min, price_max, amenities, free_cancellation, language, proxy_url
+        api_key, "", check_in, check_out, ne_lat, ne_long, sw_lat, sw_long, zoom_value, 
+        currency, place_type, price_min, price_max, amenities, free_cancellation, language, proxy_url, hash=hash
     )
 
     results = standardize.from_search(results_raw.get("searchResults", []))
@@ -194,7 +194,7 @@ def search_experience_by_taking_the_first_inputs_i_dont_care(user_input_text: st
         result = result + result_tmp
     return result
 
-def search_all_from_url(url: str, currency: str = "USD", language: str = "en", proxy_url: str = ""):
+def search_all_from_url(url: str, currency: str = "USD", language: str = "en", proxy_url: str = "", hash: str = ""):
     """
     Wrapper that parses an Airbnb search URL and delegates to search_all.
     """
@@ -248,5 +248,6 @@ def search_all_from_url(url: str, currency: str = "USD", language: str = "en", p
         free_cancellation=free_cancellation,
         currency=currency,
         language=language,
-        proxy_url=proxy_url
+        proxy_url=proxy_url,
+        hash=hash
     )

--- a/test.py
+++ b/test.py
@@ -71,8 +71,15 @@ data = pyairbnb.get_details(room_url=room_url, currency=currency,adults=4,check_
 with open('details_data.json', 'w', encoding='utf-8') as f:
     f.write(json.dumps(data))  # Convert the data to JSON and save it
 
-# Test search_all_from_url using a sample Airbnb URL with various filters
-results = pyairbnb.search_all_from_url("https://www.airbnb.com/s/Luxembourg--Luxembourg/homes?checkin=2026-05-15&checkout=2026-05-16&ne_lat=49.765370668280966&ne_lng=6.560570632398054&sw_lat=49.31155139251553&sw_lng=6.0326271739902495&zoom=10&price_min=22&price_max=200&room_types%5B%5D=Entire%20home%2Fapt&amenities%5B%5D=4&amenities%5B%5D=5&flexible_cancellation=true", currency="USD", proxy_url="")
+# Dynamically fetching operationId
+dynamic_hash = pyairbnb.fetch_stays_search_hash()
+# Test search_all_from_url using a sample Airbnb URL with various filters.
+results = pyairbnb.search_all_from_url(
+    "https://www.airbnb.com/s/Luxembourg--Luxembourg/homes?checkin=2026-05-15&checkout=2026-05-16&ne_lat=49.765370668280966&ne_lng=6.560570632398054&sw_lat=49.31155139251553&sw_lng=6.0326271739902495&zoom=10&price_min=22&price_max=200&room_types%5B%5D=Entire%20home%2Fapt&amenities%5B%5D=4&amenities%5B%5D=5&flexible_cancellation=true",
+    currency="USD",
+    proxy_url="",
+    hash=dynamic_hash,
+)
 
 with open('search_results_from_url.json', 'w', encoding='utf-8') as f:
     f.write(json.dumps(results))  # Convert the data to JSON and save it


### PR DESCRIPTION
This pull request adds support for dynamically fetching the latest `StaysSearch` operationId (hash) from Airbnb, ensuring the search API remains compatible with changes on the Airbnb website

### Dynamic hash support for Airbnb search

* Added `fetch_stays_search_hash` function in `src/pyairbnb/search.py` to programmatically retrieve the latest `StaysSearch` operationId from Airbnb website.
* Updated all relevant search functions (`search_all`, `search_first_page`, `search_all_from_url`, and underlying `get`) to accept an optional `hash` parameter, allowing use of the dynamic operationId.

### Minor improvements
* Ensured the correct hash is used in API requests and persisted query parameters, falling back to the previous hardcoded value if necessary.

reference issue: https://github.com/johnbalvin/pyairbnb/issues/38#issuecomment-3172879123