### PR TITLE
Fix imports in __init__.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *pyairbnb.egg-info
 *dist
 __pycache__
+
+# Pycharm
+.idea

--- a/src/pyairbnb/__init__.py
+++ b/src/pyairbnb/__init__.py
@@ -1,10 +1,32 @@
-from pyairbnb.utils import parse_proxy as parse_proxy, get_nested_value as get_nested_value
+from pyairbnb.utils import parse_proxy, get_nested_value
 from pyairbnb.api import get as get_api_key
-from pyairbnb.host import get_listings_from_user as get_listings_from_user
+from pyairbnb.host import get_listings_from_user
 from pyairbnb.host_details import get as get_host_details
 from pyairbnb.experience import search_by_place_id as experience_search_by_place_id
-from pyairbnb.search import get_markets as get_markets,get_places_ids as get_places_ids, fetch_stays_search_hash as fetch_stays_search_hash
-from pyairbnb.start import get_calendar as get_calendar,search_all as search_all,search_all_from_url as search_all_from_url,search_first_page as search_first_page,get_reviews as get_reviews,get_details as get_details
+from pyairbnb.search import get_markets,get_places_ids, fetch_stays_search_hash
+from pyairbnb.start import get_calendar,search_all,search_all_from_url,search_first_page,get_reviews,get_details
 from pyairbnb.start import search_experience_by_taking_the_first_inputs_i_dont_care as experience_search
 from pyairbnb.details import get as get_metadata_from_url
 from pyairbnb.price import get as get_price
+
+
+__all__ = [
+    "parse_proxy",
+    "get_nested_value",
+    "get_api_key",
+    "get_listings_from_user",
+    "get_host_details",
+    "experience_search_by_place_id",
+    "get_markets",
+    "get_places_ids",
+    "fetch_stays_search_hash",
+    "get_calendar",
+    "search_all",
+    "search_all_from_url",
+    "search_first_page",
+    "get_reviews",
+    "get_details",
+    "experience_search",
+    "get_metadata_from_url",
+    "get_price",
+]

--- a/src/pyairbnb/__init__.py
+++ b/src/pyairbnb/__init__.py
@@ -3,9 +3,18 @@ from pyairbnb.api import get as get_api_key
 from pyairbnb.host import get_listings_from_user
 from pyairbnb.host_details import get as get_host_details
 from pyairbnb.experience import search_by_place_id as experience_search_by_place_id
-from pyairbnb.search import get_markets,get_places_ids, fetch_stays_search_hash
-from pyairbnb.start import get_calendar,search_all,search_all_from_url,search_first_page,get_reviews,get_details
-from pyairbnb.start import search_experience_by_taking_the_first_inputs_i_dont_care as experience_search
+from pyairbnb.search import get_markets, get_places_ids, fetch_stays_search_hash
+from pyairbnb.start import (
+    get_calendar,
+    search_all,
+    search_all_from_url,
+    search_first_page,
+    get_reviews,
+    get_details,
+)
+from pyairbnb.start import (
+    search_experience_by_taking_the_first_inputs_i_dont_care as experience_search,
+)
 from pyairbnb.details import get as get_metadata_from_url
 from pyairbnb.price import get as get_price
 

--- a/src/pyairbnb/__init__.py
+++ b/src/pyairbnb/__init__.py
@@ -1,10 +1,10 @@
-from pyairbnb.utils import parse_proxy,get_nested_value
+from pyairbnb.utils import parse_proxy as parse_proxy, get_nested_value as get_nested_value
 from pyairbnb.api import get as get_api_key
-from pyairbnb.host import get_listings_from_user
-from pyairbnb.host_details import get_host_details
+from pyairbnb.host import get_listings_from_user as get_listings_from_user
+from pyairbnb.host_details import get as get_host_details
 from pyairbnb.experience import search_by_place_id as experience_search_by_place_id
-from pyairbnb.search import get_markets,get_places_ids,fetch_stays_search_hash
-from pyairbnb.start import get_calendar,search_all,search_all_from_url,search_first_page,get_reviews,get_details
+from pyairbnb.search import get_markets as get_markets,get_places_ids as get_places_ids, fetch_stays_search_hash as fetch_stays_search_hash
+from pyairbnb.start import get_calendar as get_calendar,search_all as search_all,search_all_from_url as search_all_from_url,search_first_page as search_first_page,get_reviews as get_reviews,get_details as get_details
 from pyairbnb.start import search_experience_by_taking_the_first_inputs_i_dont_care as experience_search
 from pyairbnb.details import get as get_metadata_from_url
 from pyairbnb.price import get as get_price


### PR DESCRIPTION
I was getting an import error from
```python
from pyairbnb.host_details import get_host_details
```

This PR fixes the import.
fix:
```python
from pyairbnb.host_details import get as get_host_details
```

Other changes:
- reformatted __init__.py to comply with PEP8 styling (https://peps.python.org/pep-0008/)
- Exposed imports in `__all__` as suggested by https://docs.astral.sh/ruff/rules/unused-import/
- add .idea folder to `.gitignore` to support Pycharm IDE