### PR TITLE
fix from missing displayComponentType key in price breakdown

### DIFF
--- a/src/pyairbnb/standardize.py
+++ b/src/pyairbnb/standardize.py
@@ -101,6 +101,8 @@ def from_map_search(resultRaw):
             for item in utils.get_nested_value(price_detail,"items",[]): 
                 amount, currency = utils.parse_price_symbol(item["priceString"])
                 data["price"]["break_down"].append({"description":item["description"],"amount":amount,"currency":currency})
+                if "displayComponentType" not in item:
+                    continue
                 match item["displayComponentType"]:
                     case "DISCOUNTED_EXPLANATION_LINE_ITEM":
                         match item["description"]:
@@ -358,6 +360,8 @@ def from_search(resultRaw):
             for item in utils.get_nested_value(price_detail,"items",[]): 
                 amount, currency = utils.parse_price_symbol(item["priceString"])
                 data["price"]["break_down"].append({"description":item["description"],"amount":amount,"currency":currency})
+                if "displayComponentType" not in item:
+                    continue
                 match item["displayComponentType"]:
                     case "DISCOUNTED_EXPLANATION_LINE_ITEM":
                         match item["description"]:


### PR DESCRIPTION
fix for error: `KeyError: 'displayComponentType'`