### PR TITLE
fix: search_first_page returns empty results

### DIFF
--- a/src/pyairbnb/start.py
+++ b/src/pyairbnb/start.py
@@ -178,7 +178,7 @@ def search_first_page(check_in: str, check_out: str, ne_lat: float, ne_long: flo
         currency, place_type, price_min, price_max, amenities, free_cancellation, adults, children, infants, min_bedrooms, min_beds, min_bathrooms, language, proxy_url, hash=hash
     )
 
-    results = standardize.from_search(results_raw.get("searchResults", []))
+    results = standardize.from_search(results_raw)
     return results
 
 


### PR DESCRIPTION
search_first_page is broken — search.get returns a list, but the code does .get("searchResults", []) on it, so you always get an empty result.

search_all on line 140 of the same file does it right (from_search(results_raw)), this just makes search_first_page match.

Hit this trying to use search_first_page in a project, took me a sec to figure out why I was getting nothing back.