### PR TITLE
Fix StaysSearch hash lookup

### DIFF
--- a/src/pyairbnb/search.py
+++ b/src/pyairbnb/search.py
@@ -56,21 +56,59 @@ def fetch_stays_search_hash(proxy_url: str = "") -> str:
     )
     bundle.raise_for_status()
 
+    js_paths = re.findall(
+        r"(?:common|[a-z]{2}(?:-[A-Za-z]{2,4})?)/[^\"'\\\s<>]+?\.js",
+        bundle.text,
+    )
     module_match = re.compile(
-        r"common/frontend/stays-search/routes/StaysSearchRoute/StaysSearchRoute\.prepare\.[^\"']+\.js"
+        r"(?:common|[a-z]{2}(?:-[A-Za-z]{2,4})?)/frontend/stays-search/routes/StaysSearchRoute/StaysSearchRoute\.prepare\.[^\"']+\.js"
     ).search(bundle.text)
     if not module_match:
         raise RuntimeError("Unable to locate StaysSearchRoute module")
 
-    module_url = f"https://a0.muscache.com/airbnb/static/packages/web/{module_match.group(0)}"
-    module = requests.get(module_url, headers=headers, proxies=proxies, impersonate="chrome124")
-    module.raise_for_status()
+    module_path = module_match.group(0)
+    candidate_paths = [module_path]
+    if module_path in js_paths:
+        module_index = js_paths.index(module_path)
+        candidate_paths = js_paths[max(0, module_index - 3):module_index + 36]
 
-    hash_match = re.compile(r"operationId:['\"]([0-9a-f]{64})").search(module.text)
-    if not hash_match:
-        raise RuntimeError("Unable to extract StaysSearch operationId")
+    operation_patterns = [
+        re.compile(
+            r"['\"]?(?:name|operationName)['\"]?\s*:\s*['\"]StaysSearch['\"][\s\S]{0,2000}?"
+            r"['\"]?(?:operationId|sha256Hash)['\"]?\s*:\s*['\"]([0-9a-f]{64})['\"]"
+        ),
+        re.compile(
+            r"['\"]?(?:operationId|sha256Hash)['\"]?\s*:\s*['\"]([0-9a-f]{64})['\"][\s\S]{0,2000}?"
+            r"['\"]?(?:name|operationName)['\"]?\s*:\s*['\"]StaysSearch['\"]"
+        ),
+        re.compile(r"/api/v3/StaysSearch/([0-9a-f]{64})"),
+        re.compile(r"StaysSearch/([0-9a-f]{64})"),
+    ]
 
-    return hash_match.group(1)
+    visited_paths = set()
+    for path in candidate_paths:
+        if path in visited_paths:
+            continue
+        visited_paths.add(path)
+
+        module_url = f"https://a0.muscache.com/airbnb/static/packages/web/{path}"
+        module = requests.get(module_url, headers=headers, proxies=proxies, impersonate="chrome124")
+        module.raise_for_status()
+
+        for pattern in operation_patterns:
+            hash_match = pattern.search(module.text)
+            if hash_match:
+                return hash_match.group(1)
+
+        if path == module_path:
+            hash_matches = re.findall(
+                r"['\"]?(?:operationId|sha256Hash)['\"]?\s*:\s*['\"]([0-9a-f]{64})['\"]",
+                module.text,
+            )
+            if len(hash_matches) == 1:
+                return hash_matches[0]
+
+    raise RuntimeError("Unable to extract StaysSearch operationId")
 
 def get(api_key:str, cursor:str, check_in:str, check_out:str, ne_lat:float, ne_long:float, sw_lat:float, sw_long:float, zoom_value:int, currency:str, place_type: str, price_min: int, price_max: int, amenities: list, free_cancellation: bool, adults: int, children: int, infants: int, min_bedrooms: int, min_beds: int, min_bathrooms: int, language: str, proxy_url:str, hash:str):
     


### PR DESCRIPTION
## What changed

Airbnb moved the `StaysSearch` operation id out of the route chunk this code was checking directly. The lookup was still finding the route module, but then failed because the hash now lives in a nearby JS chunk.

This updates `fetch_stays_search_hash` to:

- keep the same homepage / asyncRequire / route-module flow
- collect nearby JS chunks from the asyncRequire bundle
- scan those chunks for the `StaysSearch` query hash
- support both `operationId` and `sha256Hash` formats

## Why

The previous implementation was too tightly tied to one bundle shape and one exact `operationId` placement, so the method broke even though the hash was still available in Airbnb’s loaded assets.

## Testing

```
dynamic_hash = pyairbnb.fetch_stays_search_hash()
print(dynamic_hash)
```