### PR TITLE
Add timeout support to HTTP functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ to match the name with pip name
 ## Important
 - With the new airbnb changes, if you want to get the price from a room url you need to specify the date range
 the date range should be on the format year-month-day, if you leave the date range empty, you will get the details but not the price
+- All HTTP-facing functions accept a `timeout` argument. It defaults to 60 seconds, accepts the same values as `curl_cffi` (`int`, `float`, `(connect_timeout, read_timeout)` tuple), and can be set to `None` to disable timeouts.
 
 
 ### Install
@@ -65,7 +66,8 @@ search_results = pyairbnb.search_all(
     free_cancellation=free_cancellation,
     currency=currency,
     language=language,
-    proxy_url=proxy_url
+    proxy_url=proxy_url,
+    timeout=30,
 )
 
 # Save the search results as a JSON file
@@ -112,6 +114,7 @@ data = pyairbnb.get_price(
     room_id="1316896675409654026",
     check_in=date(2026, 2, 4),
     check_out=date(2026, 2, 7),
+    timeout=30,
 )
 ```
 

--- a/src/pyairbnb/api.py
+++ b/src/pyairbnb/api.py
@@ -1,11 +1,12 @@
 from curl_cffi import requests
 import re
+from pyairbnb.utils import DEFAULT_TIMEOUT, Timeout
 
 ep = "https://www.airbnb.com"
 
 regx_api_key = re.compile(r'"api_config":{"key":".+?"')
 
-def get(proxy_url: str) -> str:
+def get(proxy_url: str, timeout: Timeout = DEFAULT_TIMEOUT) -> str:
     headers = {
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
         "Accept-Language": "en",
@@ -25,7 +26,7 @@ def get(proxy_url: str) -> str:
     if proxy_url:
         proxies = {"http": proxy_url, "https": proxy_url}
 
-    response = requests.get(ep, headers=headers, proxies=proxies, timeout=60)  
+    response = requests.get(ep, headers=headers, proxies=proxies, timeout=timeout)
     response.raise_for_status() 
 
     body = response.text

--- a/src/pyairbnb/calendarinfo.py
+++ b/src/pyairbnb/calendarinfo.py
@@ -2,11 +2,12 @@ from curl_cffi import requests
 import pyairbnb.utils as utils
 from urllib.parse import urlencode
 import json
+from pyairbnb.utils import DEFAULT_TIMEOUT, Timeout
 
 ep = "https://www.airbnb.com/api/v3/PdpAvailabilityCalendar/8f08e03c7bd16fcad3c92a3592c19a8b559a0d0855a84028d1163d4733ed9ade/"
  
 
-def get(api_key: str, room_id: str, month: int, year: int, proxy_url: str) -> str:
+def get(api_key: str, room_id: str, month: int, year: int, proxy_url: str, timeout: Timeout = DEFAULT_TIMEOUT) -> str:
     headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
@@ -40,7 +41,7 @@ def get(api_key: str, room_id: str, month: int, year: int, proxy_url: str) -> st
     proxies = {}
     if proxy_url:
         proxies = {"http": proxy_url, "https": proxy_url}
-    response = requests.get(url, headers=headers, proxies=proxies, timeout=60)
+    response = requests.get(url, headers=headers, proxies=proxies, timeout=timeout)
     response.raise_for_status() 
     data = response.json()
     calendar = utils.get_nested_value(data,"data.merlin.pdpAvailabilityCalendar.calendarMonths",[])

--- a/src/pyairbnb/details.py
+++ b/src/pyairbnb/details.py
@@ -1,9 +1,10 @@
 from curl_cffi import requests
 import pyairbnb.parse as parse
+from pyairbnb.utils import DEFAULT_TIMEOUT, Timeout
 
 
 
-def get(room_url: str, language: str, proxy_url: str):
+def get(room_url: str, language: str, proxy_url: str, timeout: Timeout = DEFAULT_TIMEOUT):
     headers = {
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
         "Accept-Language": language,
@@ -22,7 +23,7 @@ def get(room_url: str, language: str, proxy_url: str):
     proxies = {}
     if proxy_url:
         proxies = {"http": proxy_url, "https": proxy_url}
-    response = requests.get(room_url, headers=headers, proxies=proxies)
+    response = requests.get(room_url, headers=headers, proxies=proxies, timeout=timeout)
     response.raise_for_status()
     data_formatted, price_dependency_input=parse.parse_body_details_wrapper(response.text)
     cookies = response.cookies

--- a/src/pyairbnb/experience.py
+++ b/src/pyairbnb/experience.py
@@ -2,6 +2,7 @@ from curl_cffi import requests
 from urllib.parse import urlencode
 import pyairbnb.utils as utils
 import uuid
+from pyairbnb.utils import DEFAULT_TIMEOUT, Timeout
 
 ep_search = "https://www.airbnb.com/api/v3/ExperiencesSearch/fbbf9989cdf264a11fce48073008bb557f7f6b43961ccda5df6a8d988bd6ef36"
 headers = {
@@ -21,7 +22,7 @@ headers = {
     "Upgrade-Insecure-Requests": "1",
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 }
-def search_by_place_id(cursor: str, place_id: str, location_name: str, currency:str, locale: str, check_in:str, check_out:str, api_key:str, proxy_url:str):
+def search_by_place_id(cursor: str, place_id: str, location_name: str, currency:str, locale: str, check_in:str, check_out:str, api_key:str, proxy_url:str, timeout: Timeout = DEFAULT_TIMEOUT):
     query_params = {
         "operationName": "ExperiencesSearch",
         "locale": locale,
@@ -81,7 +82,7 @@ def search_by_place_id(cursor: str, place_id: str, location_name: str, currency:
     proxies = {}
     if proxy_url:
         proxies = {"http": proxy_url, "https": proxy_url}
-    response = requests.post(url_parsed, json = inputData, headers=headers_copy, proxies=proxies,  impersonate="chrome124")
+    response = requests.post(url_parsed, json = inputData, headers=headers_copy, proxies=proxies,  impersonate="chrome124", timeout=timeout)
     if response.status_code != 200:
         raise Exception("Not corret status code: ", response.status_code, " response body: ",response.text)
     data = response.json()

--- a/src/pyairbnb/host.py
+++ b/src/pyairbnb/host.py
@@ -2,6 +2,7 @@ from curl_cffi import requests
 from urllib.parse import urlencode
 import pyairbnb.utils as utils
 import json
+from pyairbnb.utils import DEFAULT_TIMEOUT, Timeout
 
 ep = "https://www.airbnb.com/api/v3/UserProfileBeehiveListingQuery/529ca816b8be0619618d48b31bf46c379543e297fd68c0a953922927e5497b43"
 
@@ -14,18 +15,18 @@ extension = {
 
 extensionRaw = json.dumps(extension)
         
-def get_listings_from_user(userId: int, api_key: str, proxy_url: str):
+def get_listings_from_user(userId: int, api_key: str, proxy_url: str, timeout: Timeout = DEFAULT_TIMEOUT):
     offset = 0
     all_listings = []
     while True:
-        listings = get_listings_from_offset(offset, userId, api_key, proxy_url)
+        listings = get_listings_from_offset(offset, userId, api_key, proxy_url, timeout=timeout)
         offset = offset + len(listings)
         if len(listings)==0:
             break
         all_listings = all_listings + listings
     return all_listings
 
-def get_listings_from_offset(offset: int, userId: int, api_key: str, proxy_url: str) -> str:
+def get_listings_from_offset(offset: int, userId: int, api_key: str, proxy_url: str, timeout: Timeout = DEFAULT_TIMEOUT) -> str:
     variables = {
         "userId": userId,
         "limit": 12,
@@ -57,7 +58,7 @@ def get_listings_from_offset(offset: int, userId: int, api_key: str, proxy_url: 
         "Upgrade-Insecure-Requests": "1",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     }
-    response = requests.get(url_parsed, headers=headers, proxies=proxies, timeout=60)  
+    response = requests.get(url_parsed, headers=headers, proxies=proxies, timeout=timeout)
     response.raise_for_status() 
     data = response.json()
     listings = utils.get_nested_value(data,"data.beehive.getListOfListings.listings",[])

--- a/src/pyairbnb/host_details.py
+++ b/src/pyairbnb/host_details.py
@@ -1,8 +1,9 @@
 from curl_cffi import requests
 import json
 import base64
+from pyairbnb.utils import DEFAULT_TIMEOUT, Timeout
 
-def get(api_key: str, cookies, host_id: str, language: str, proxy_url: str):
+def get(api_key: str, cookies, host_id: str, language: str, proxy_url: str, timeout: Timeout = DEFAULT_TIMEOUT):
     # Encode the host ID to match Airbnb's required format
     host_id = 'User:' + host_id
     user_id = base64.b64encode(host_id.encode()).decode('utf-8')
@@ -43,7 +44,8 @@ def get(api_key: str, cookies, host_id: str, language: str, proxy_url: str):
         params=params,
         headers=headers,
         cookies=cookies,
-        proxies=proxies
+        proxies=proxies,
+        timeout=timeout,
     )
 
     # Raise an exception if the request failed

--- a/src/pyairbnb/price.py
+++ b/src/pyairbnb/price.py
@@ -5,6 +5,7 @@ import pyairbnb.utils as utils
 from urllib.parse import urlencode
 import pyairbnb.api as api
 import pyairbnb.standardize as standardize
+from pyairbnb.utils import DEFAULT_TIMEOUT, Timeout
 
 
 class UnavailableError(Exception):
@@ -16,12 +17,12 @@ BASE_URL = "https://www.airbnb.com/api/v3/StaysPdpSections"
 PERSISTED_QUERY_HASH = "80c7889b4b0027d99ffea830f6c0d4911a6e863a957cbe1044823f0fc746bf1f"
 
 
-def _build_headers(api_key: str | None, proxy_url: str | None) -> dict:
+def _build_headers(api_key: str | None, proxy_url: str | None, timeout: Timeout = DEFAULT_TIMEOUT) -> dict:
     return {
         "Accept": "application/json",
         "Content-Type": "application/json",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",  # TO-DO randomize this later
-        "X-Airbnb-Api-Key": api_key or api.get(proxy_url),
+        "X-Airbnb-Api-Key": api_key or api.get(proxy_url, timeout=timeout),
     }
 
 
@@ -135,6 +136,7 @@ def get(
     api_key: str | None = None,
     cookies: list | None = None, 
     proxy_url: str | None = None,
+    timeout: Timeout = DEFAULT_TIMEOUT,
 ) -> dict:
     extension = _build_query_extension()
     variables = _build_query_variables(
@@ -153,11 +155,11 @@ def get(
     }
 
     url = f"{BASE_URL}/{PERSISTED_QUERY_HASH}?{urlencode(query)}"
-    headers = _build_headers(api_key, proxy_url)
+    headers = _build_headers(api_key, proxy_url, timeout=timeout)
     proxies = {"http": proxy_url, "https": proxy_url} if proxy_url else None
     with requests.Session() as session:
         session.cookies.update(cookies)
-        response = session.get(url=url, headers=headers, proxies=proxies)
+        response = session.get(url=url, headers=headers, proxies=proxies, timeout=timeout)
     
     response.raise_for_status()
     data = response.json()

--- a/src/pyairbnb/reviews.py
+++ b/src/pyairbnb/reviews.py
@@ -2,21 +2,22 @@ from curl_cffi import requests
 import pyairbnb.utils as utils
 from urllib.parse import urlencode
 import json
+from pyairbnb.utils import DEFAULT_TIMEOUT, Timeout
 
 ep="https://www.airbnb.com/api/v3/StaysPdpReviewsQuery/dec1c8061483e78373602047450322fd474e79ba9afa8d3dbbc27f504030f91d/"
 
-def get(api_key: str = "", product_id: str= "", currency: str = "USD", language: str = "en", proxy_url: str = None) -> str:
+def get(api_key: str = "", product_id: str= "", currency: str = "USD", language: str = "en", proxy_url: str = None, timeout: Timeout = DEFAULT_TIMEOUT) -> str:
     offset = 0
     all_reviews = []
     while True:
-        reviews = get_from_offset(api_key, offset, product_id, currency, language, proxy_url)
+        reviews = get_from_offset(api_key, offset, product_id, currency, language, proxy_url, timeout=timeout)
         offset=offset+50
         if len(reviews)==0:
             break
         all_reviews.extend(reviews)
     return all_reviews    
 
-def get_from_offset(api_key: str, offset: int, product_id: str, currency: str = "USD", language: str = "en", proxy_url: str = None) -> str:
+def get_from_offset(api_key: str, offset: int, product_id: str, currency: str = "USD", language: str = "en", proxy_url: str = None, timeout: Timeout = DEFAULT_TIMEOUT) -> str:
     headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
@@ -59,7 +60,7 @@ def get_from_offset(api_key: str, offset: int, product_id: str, currency: str = 
     proxies = {}
     if proxy_url:
         proxies = {"http": proxy_url, "https": proxy_url}
-    response = requests.get(url, headers=headers, proxies=proxies, timeout=60)
+    response = requests.get(url, headers=headers, proxies=proxies, timeout=timeout)
     response.raise_for_status() 
     data = response.json()
     reviews = utils.get_nested_value(data,"data.presentation.stayProductDetailPage.reviews.reviews",{})

--- a/src/pyairbnb/search.py
+++ b/src/pyairbnb/search.py
@@ -3,6 +3,7 @@ from urllib.parse import urlencode
 import pyairbnb.utils as utils
 from curl_cffi import requests
 import re
+from pyairbnb.utils import DEFAULT_TIMEOUT, Timeout
 
 ep_autocomplete = "https://www.airbnb.com/api/v2/autocompletes-personalized"
 ep_market = "https://www.airbnb.com/api/v2/user_markets"
@@ -33,7 +34,7 @@ headers_global = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 }
 
-def fetch_stays_search_hash(proxy_url: str = "") -> str:
+def fetch_stays_search_hash(proxy_url: str = "", timeout: Timeout = DEFAULT_TIMEOUT) -> str:
     proxies = {"http": proxy_url, "https": proxy_url} if proxy_url else None
     headers = {"User-Agent": headers_global["User-Agent"]}
 
@@ -42,6 +43,7 @@ def fetch_stays_search_hash(proxy_url: str = "") -> str:
         headers=headers,
         proxies=proxies,
         impersonate="chrome124",
+        timeout=timeout,
     )
     homepage.raise_for_status()
 
@@ -52,7 +54,7 @@ def fetch_stays_search_hash(proxy_url: str = "") -> str:
         raise RuntimeError("Unable to locate StaysSearch bundle")
 
     bundle = requests.get(
-        bundle_match.group(0), headers=headers, proxies=proxies, impersonate="chrome124"
+        bundle_match.group(0), headers=headers, proxies=proxies, impersonate="chrome124", timeout=timeout
     )
     bundle.raise_for_status()
 
@@ -63,7 +65,7 @@ def fetch_stays_search_hash(proxy_url: str = "") -> str:
         raise RuntimeError("Unable to locate StaysSearchRoute module")
 
     module_url = f"https://a0.muscache.com/airbnb/static/packages/web/{module_match.group(0)}"
-    module = requests.get(module_url, headers=headers, proxies=proxies, impersonate="chrome124")
+    module = requests.get(module_url, headers=headers, proxies=proxies, impersonate="chrome124", timeout=timeout)
     module.raise_for_status()
 
     hash_match = re.compile(r"operationId:['\"]([0-9a-f]{64})").search(module.text)
@@ -72,7 +74,7 @@ def fetch_stays_search_hash(proxy_url: str = "") -> str:
 
     return hash_match.group(1)
 
-def get(api_key:str, cursor:str, check_in:str, check_out:str, ne_lat:float, ne_long:float, sw_lat:float, sw_long:float, zoom_value:int, currency:str, place_type: str, price_min: int, price_max: int, amenities: list, free_cancellation: bool, adults: int, children: int, infants: int, min_bedrooms: int, min_beds: int, min_bathrooms: int, language: str, proxy_url:str, hash:str):
+def get(api_key:str, cursor:str, check_in:str, check_out:str, ne_lat:float, ne_long:float, sw_lat:float, sw_long:float, zoom_value:int, currency:str, place_type: str, price_min: int, price_max: int, amenities: list, free_cancellation: bool, adults: int, children: int, infants: int, min_bedrooms: int, min_beds: int, min_bathrooms: int, language: str, proxy_url:str, hash:str, timeout: Timeout = DEFAULT_TIMEOUT):
     
     operationId = hash if hash else '9f945886dcc032b9ef4ba770d9132eb0aa78053296b5405483944c229617b00b'
     base_url = f"https://www.airbnb.com/api/v3/StaysSearch/{operationId}"
@@ -205,13 +207,13 @@ def get(api_key:str, cursor:str, check_in:str, check_out:str, ne_lat:float, ne_l
     proxies = {}
     if proxy_url:
         proxies = {"http": proxy_url, "https": proxy_url}
-    response = requests.post(url_parsed, json = inputData, headers=headers_copy, proxies=proxies,  impersonate="chrome124")
+    response = requests.post(url_parsed, json = inputData, headers=headers_copy, proxies=proxies,  impersonate="chrome124", timeout=timeout)
     if response.status_code != 200:
         raise Exception("Not corret status code: ", response.status_code, " response body: ",response.text)
     data = response.json()
     return data
 
-def get_markets(currency: str, locale: str, api_key: str, proxy_url: str):
+def get_markets(currency: str, locale: str, api_key: str, proxy_url: str, timeout: Timeout = DEFAULT_TIMEOUT):
     query_params = {
         "locale": locale,
         "currency": currency,
@@ -223,13 +225,13 @@ def get_markets(currency: str, locale: str, api_key: str, proxy_url: str):
     proxies = {}
     if proxy_url:
         proxies = {"http": proxy_url, "https": proxy_url}
-    response = requests.get(url_parsed, headers=headers_copy, proxies=proxies, impersonate="chrome124")
+    response = requests.get(url_parsed, headers=headers_copy, proxies=proxies, impersonate="chrome124", timeout=timeout)
     if response.status_code != 200:
         raise Exception("Not corret status code: ", response.status_code, " response body: ",response.text)
     data = response.json()
     return data
 
-def get_places_ids(country: str, location_name: str, currency: str, locale: str, config_token: str, api_key: str, proxy_url: str):
+def get_places_ids(country: str, location_name: str, currency: str, locale: str, config_token: str, api_key: str, proxy_url: str, timeout: Timeout = DEFAULT_TIMEOUT):
     query_params = {
         "currency": currency,
         "country": country,
@@ -250,7 +252,7 @@ def get_places_ids(country: str, location_name: str, currency: str, locale: str,
     proxies = {}
     if proxy_url:
         proxies = {"http": proxy_url, "https": proxy_url}
-    response = requests.get(url_parsed, headers=headers_copy, proxies=proxies, impersonate="chrome124")
+    response = requests.get(url_parsed, headers=headers_copy, proxies=proxies, impersonate="chrome124", timeout=timeout)
     if response.status_code != 200:
         raise Exception("Not corret status code: ", response.status_code, " response body: ",response.text)
     data = response.json()

--- a/src/pyairbnb/start.py
+++ b/src/pyairbnb/start.py
@@ -8,10 +8,11 @@ import pyairbnb.standardize as standardize
 import pyairbnb.experience as experience
 import pyairbnb.calendarinfo as calendar
 import pyairbnb.host_details as host_details
+from pyairbnb.utils import DEFAULT_TIMEOUT, Timeout
 from datetime import datetime
 from urllib.parse import urlparse
 
-def get_calendar(api_key: str = "", room_id: str = "", proxy_url: str = ""):
+def get_calendar(api_key: str = "", room_id: str = "", proxy_url: str = "", timeout: Timeout = DEFAULT_TIMEOUT):
     """
     Retrieves the calendar data for a specified room.
 
@@ -24,13 +25,13 @@ def get_calendar(api_key: str = "", room_id: str = "", proxy_url: str = ""):
         dict: Calendar data.
     """
     if not api_key:
-        api_key = api.get(proxy_url)
+        api_key = api.get(proxy_url, timeout=timeout)
 
     current_month = datetime.now().month
     current_year = datetime.now().year
-    return calendar.get(api_key, room_id, current_month, current_year, proxy_url)
+    return calendar.get(api_key, room_id, current_month, current_year, proxy_url, timeout=timeout)
 
-def get_reviews(room_url: str ,language: str = "en", proxy_url: str = ""):
+def get_reviews(room_url: str ,language: str = "en", proxy_url: str = "", timeout: Timeout = DEFAULT_TIMEOUT):
     """
     Retrieves review data for a specified product.
 
@@ -43,13 +44,13 @@ def get_reviews(room_url: str ,language: str = "en", proxy_url: str = ""):
     Returns:
         dict: Reviews data.
     """
-    data, price_input, cookies = details.get(room_url, language, proxy_url)
+    data, price_input, cookies = details.get(room_url, language, proxy_url, timeout=timeout)
     product_id = price_input["product_id"]
     api_key = price_input["api_key"]
 
-    return reviews.get(api_key, product_id, "USD", language, proxy_url)
+    return reviews.get(api_key, product_id, "USD", language, proxy_url, timeout=timeout)
 
-def get_details(room_url: str = None, room_id: int = None, domain: str = "www.airbnb.com", check_in: str = None, check_out: str = None, adults: int = 1, currency: str = "USD", language: str = "en", proxy_url: str = ""):
+def get_details(room_url: str = None, room_id: int = None, domain: str = "www.airbnb.com", check_in: str = None, check_out: str = None, adults: int = 1, currency: str = "USD", language: str = "en", proxy_url: str = "", timeout: Timeout = DEFAULT_TIMEOUT):
     """
     Retrieves all details (calendar, reviews, price, and host details) for a specified room.
 
@@ -72,7 +73,7 @@ def get_details(room_url: str = None, room_id: int = None, domain: str = "www.ai
     if not room_url:
         room_url = f"https://{domain}/rooms/{room_id}"
     
-    data, price_input, cookies = details.get(room_url, language, proxy_url)
+    data, price_input, cookies = details.get(room_url, language, proxy_url, timeout=timeout)
     product_id = price_input["product_id"]
     api_key = price_input["api_key"]
     
@@ -83,25 +84,25 @@ def get_details(room_url: str = None, room_id: int = None, domain: str = "www.ai
         room_id = path.split("/")[-1]
     
     # Get calendar and reviews data
-    data["reviews"] = reviews.get(api_key, product_id, currency, language, proxy_url)
-    data["calendar"] = get_calendar(api_key, room_id, proxy_url)
+    data["reviews"] = reviews.get(api_key, product_id, currency, language, proxy_url, timeout=timeout)
+    data["calendar"] = get_calendar(api_key, room_id, proxy_url, timeout=timeout)
     
     # Get price data if check-in and check-out dates are provided
     if check_in and check_out:
         price_data = price.get(
-            api_key, cookies, price_input["impression_id"], product_id, check_in, check_out, adults, 
-            currency, language, proxy_url
+            api_key, cookies, price_input["impression_id"], product_id, check_in, check_out, adults,
+            currency, language, proxy_url, timeout=timeout
         )
         data["price"] = price_data
     
     # Get host details
     host_id = data["host"]["id"]
-    data["host_details"] = host_details.get(api_key, cookies, host_id, language, proxy_url)
+    data["host_details"] = host_details.get(api_key, cookies, host_id, language, proxy_url, timeout=timeout)
     
     return data
 
 def search_all(check_in: str, check_out: str, ne_lat: float, ne_long: float, sw_lat: float, sw_long: float,
-               zoom_value: int, price_min: int, price_max: int, place_type: str = "", amenities: list = [], free_cancellation: bool = False, adults: int = 0, children: int = 0, infants: int = 0, min_bedrooms: int = 0, min_beds: int = 0, min_bathrooms: int = 0, currency: str = "USD", language: str = "en", proxy_url: str = "", hash: str = ""):
+               zoom_value: int, price_min: int, price_max: int, place_type: str = "", amenities: list = [], free_cancellation: bool = False, adults: int = 0, children: int = 0, infants: int = 0, min_bedrooms: int = 0, min_beds: int = 0, min_bathrooms: int = 0, currency: str = "USD", language: str = "en", proxy_url: str = "", hash: str = "", timeout: Timeout = DEFAULT_TIMEOUT):
     """
     Performs a paginated search for all rooms within specified geographic bounds.
 
@@ -128,13 +129,13 @@ def search_all(check_in: str, check_out: str, ne_lat: float, ne_long: float, sw_
     Returns:
         list: A list of all search results.
     """
-    api_key = api.get(proxy_url)
+    api_key = api.get(proxy_url, timeout=timeout)
     all_results = []
     cursor = ""
     while True:
         results_raw = search.get(
             api_key, cursor, check_in, check_out, ne_lat, ne_long, sw_lat, sw_long, zoom_value,
-            currency, place_type, price_min, price_max, amenities, free_cancellation, adults, children, infants, min_bedrooms, min_beds, min_bathrooms, language, proxy_url, hash
+            currency, place_type, price_min, price_max, amenities, free_cancellation, adults, children, infants, min_bedrooms, min_beds, min_bathrooms, language, proxy_url, hash, timeout=timeout
         )
         paginationInfo = utils.get_nested_value(results_raw,"data.presentation.staysSearch.results.paginationInfo",{})
         results = standardize.from_search(results_raw)
@@ -145,7 +146,7 @@ def search_all(check_in: str, check_out: str, ne_lat: float, ne_long: float, sw_
     return all_results
 
 def search_first_page(check_in: str, check_out: str, ne_lat: float, ne_long: float, sw_lat: float, sw_long: float,
-               zoom_value: int, price_min: int, price_max: int, place_type: str = "", amenities: list = [], free_cancellation: bool = False, adults: int = 0, children: int = 0, infants: int = 0, min_bedrooms: int = 0, min_beds: int = 0, min_bathrooms: int = 0, currency: str = "USD", language: str = "en", proxy_url: str = "", hash: str = ""):
+               zoom_value: int, price_min: int, price_max: int, place_type: str = "", amenities: list = [], free_cancellation: bool = False, adults: int = 0, children: int = 0, infants: int = 0, min_bedrooms: int = 0, min_beds: int = 0, min_bathrooms: int = 0, currency: str = "USD", language: str = "en", proxy_url: str = "", hash: str = "", timeout: Timeout = DEFAULT_TIMEOUT):
     """
     Searches the first page of results within specified geographic bounds.
 
@@ -172,18 +173,18 @@ def search_first_page(check_in: str, check_out: str, ne_lat: float, ne_long: flo
     Returns:
         list: A list of search results from the first page.
     """
-    api_key = api.get(proxy_url)
+    api_key = api.get(proxy_url, timeout=timeout)
     results_raw = search.get(
         api_key, "", check_in, check_out, ne_lat, ne_long, sw_lat, sw_long, zoom_value,
-        currency, place_type, price_min, price_max, amenities, free_cancellation, adults, children, infants, min_bedrooms, min_beds, min_bathrooms, language, proxy_url, hash=hash
+        currency, place_type, price_min, price_max, amenities, free_cancellation, adults, children, infants, min_bedrooms, min_beds, min_bathrooms, language, proxy_url, hash=hash, timeout=timeout
     )
 
     results = standardize.from_search(results_raw.get("searchResults", []))
     return results
 
 
-def search_experience_by_taking_the_first_inputs_i_dont_care(user_input_text: str, currency:str, locale: str, check_in:str, check_out:str, api_key:str, proxy_url:str):
-    markets_data = search.get_markets(currency,locale,api_key,proxy_url)
+def search_experience_by_taking_the_first_inputs_i_dont_care(user_input_text: str, currency:str, locale: str, check_in:str, check_out:str, api_key:str, proxy_url:str, timeout: Timeout = DEFAULT_TIMEOUT):
+    markets_data = search.get_markets(currency,locale,api_key,proxy_url, timeout=timeout)
     markets = utils.get_nested_value(markets_data,"user_markets", [])
     if len(markets)==0:
         raise Exception("markets are empty")
@@ -191,22 +192,22 @@ def search_experience_by_taking_the_first_inputs_i_dont_care(user_input_text: st
     country_code = utils.get_nested_value(markets[0],"country_code", "")
     if config_token=="" or country_code=="":
         raise Exception("config_token or country_code are empty")
-    place_ids_results = search.get_places_ids(country_code, user_input_text, currency, locale, config_token, api_key, proxy_url)
+    place_ids_results = search.get_places_ids(country_code, user_input_text, currency, locale, config_token, api_key, proxy_url, timeout=timeout)
     if len(place_ids_results)==0:
         raise Exception("empty places ids")
     place_id = utils.get_nested_value(place_ids_results[0],"location.google_place_id", "")
     location_name = utils.get_nested_value(place_ids_results[0],"location.location_name", "")
     if place_id=="" or location_name=="":
         raise Exception("place_id or location_name are empty")
-    [result,cursor] = experience.search_by_place_id("", place_id, location_name, currency, locale, check_in, check_out, api_key, proxy_url)
+    [result,cursor] = experience.search_by_place_id("", place_id, location_name, currency, locale, check_in, check_out, api_key, proxy_url, timeout=timeout)
     while cursor!="":
-        [result_tmp,cursor] = experience.search_by_place_id(cursor, place_id, location_name, currency, locale, check_in, check_out, api_key, proxy_url)
+        [result_tmp,cursor] = experience.search_by_place_id(cursor, place_id, location_name, currency, locale, check_in, check_out, api_key, proxy_url, timeout=timeout)
         if len(result_tmp)==0:
             break
         result = result + result_tmp
     return result
 
-def search_all_from_url(url: str, currency: str = "USD", language: str = "en", proxy_url: str = "", hash: str = ""):
+def search_all_from_url(url: str, currency: str = "USD", language: str = "en", proxy_url: str = "", hash: str = "", timeout: Timeout = DEFAULT_TIMEOUT):
     """
     Wrapper that parses an Airbnb search URL and delegates to search_all.
     """
@@ -277,5 +278,6 @@ def search_all_from_url(url: str, currency: str = "USD", language: str = "en", p
         currency=currency,
         language=language,
         proxy_url=proxy_url,
-        hash=hash
+        hash=hash,
+        timeout=timeout,
     )

--- a/src/pyairbnb/utils.py
+++ b/src/pyairbnb/utils.py
@@ -1,6 +1,10 @@
 import re
+from typing import TypeAlias
 from urllib.parse import quote
 
+
+Timeout: TypeAlias = int | float | tuple[int | float, int | float] | None
+DEFAULT_TIMEOUT: Timeout = 60
 
 regex_space = re.compile(r'[\s ]+')
 regx_price = re.compile(r'\d+')


### PR DESCRIPTION
This adds a configurable `timeout` argument across the HTTP-facing `pyairbnb` APIs. The default is `60` seconds, and callers can pass any `curl_cffi` timeout value, including numeric seconds, `(connect, read)` tuples, or `None`.