### PR TITLE
fix: search_all_from_url forwards all URL filters to Airbnb

### DIFF
--- a/src/pyairbnb/search.py
+++ b/src/pyairbnb/search.py
@@ -1,11 +1,44 @@
 from datetime import datetime
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse, parse_qs
 import pyairbnb.utils as utils
 from curl_cffi import requests
 import re
 
 ep_autocomplete = "https://www.airbnb.com/api/v2/autocompletes-personalized"
 ep_market = "https://www.airbnb.com/api/v2/user_markets"
+
+# Filters Airbnb's API expects in snake_case. Everything else: snake → camel.
+_SNAKE_FILTERS = {"amenities", "room_types", "selected_filter_order", "flexible_cancellation",
+          "price_min", "price_max", "min_bedrooms", "min_beds", "min_bathrooms"}
+
+_UI_DEFAULTS = {"cdnCacheSafe": "false", "channel": "EXPLORE", "datePickerType": "calendar",
+                "itemsPerGrid": "50", "priceFilterInputType": "0", "screenSize": "large",
+                "searchByMap": "true", "version": "1.8.3"}
+
+
+def _filter_name(url_key):
+    if url_key == "zoom": url_key = "zoom_level"
+    if url_key in _SNAKE_FILTERS or "_" not in url_key: return url_key
+    head, *tail = url_key.split("_")
+    return head + "".join(word.capitalize() for word in tail)
+
+
+def url_to_raw_params(url):
+    query_params = parse_qs(urlparse(url).query)
+    raw_params = [{"filterName": _filter_name(key[:-2] if key.endswith("[]") else key),
+                   "filterValues": [str(value) for value in values]} for key, values in query_params.items()]
+    seen_names = {param["filterName"] for param in raw_params}
+
+    checkin = query_params.get("checkin", [None])[0]
+    checkout = query_params.get("checkout", [None])[0]
+    if checkin and checkout and "priceFilterNumNights" not in seen_names:
+        days = (datetime.strptime(checkout, "%Y-%m-%d") - datetime.strptime(checkin, "%Y-%m-%d")).days
+        raw_params.append({"filterName": "priceFilterNumNights", "filterValues": [str(days)]})
+        seen_names.add("priceFilterNumNights")
+
+    raw_params += [{"filterName": name, "filterValues": [value]}
+                   for name, value in _UI_DEFAULTS.items() if name not in seen_names]
+    return raw_params
 
 treament = [
 	"feed_map_decouple_m11_treatment",
@@ -72,8 +105,8 @@ def fetch_stays_search_hash(proxy_url: str = "") -> str:
 
     return hash_match.group(1)
 
-def get(api_key:str, cursor:str, check_in:str, check_out:str, ne_lat:float, ne_long:float, sw_lat:float, sw_long:float, zoom_value:int, currency:str, place_type: str, price_min: int, price_max: int, amenities: list, free_cancellation: bool, adults: int, children: int, infants: int, min_bedrooms: int, min_beds: int, min_bathrooms: int, language: str, proxy_url:str, hash:str):
-    
+def get(api_key:str, cursor:str, check_in:str, check_out:str, ne_lat:float, ne_long:float, sw_lat:float, sw_long:float, zoom_value:int, currency:str, place_type: str, price_min: int, price_max: int, amenities: list, free_cancellation: bool, adults: int, children: int, infants: int, min_bedrooms: int, min_beds: int, min_bathrooms: int, language: str, proxy_url:str, hash:str, raw_params: list = None):
+
     operationId = hash if hash else '9f945886dcc032b9ef4ba770d9132eb0aa78053296b5405483944c229617b00b'
     base_url = f"https://www.airbnb.com/api/v3/StaysSearch/{operationId}"
 
@@ -83,88 +116,92 @@ def get(api_key:str, cursor:str, check_in:str, check_out:str, ne_lat:float, ne_l
         "currency": currency,
     }
     url_parsed = f"{base_url}?{urlencode(query_params)}"
-    rawParams=[
-        {"filterName":"cdnCacheSafe","filterValues":["false"]},
-        {"filterName":"channel","filterValues":["EXPLORE"]},
-        {"filterName":"datePickerType","filterValues":["calendar"]},
-        {"filterName":"flexibleTripLengths","filterValues":["one_week"]},
-        {"filterName":"itemsPerGrid","filterValues":["50"]},#if you read this, this is items returned number, this can bex exploited  ;)
-        {"filterName":"monthlyLength","filterValues":["3"]},
+
+    if raw_params is not None:
+        rawParams = raw_params
+    else:
+        rawParams=[
+            {"filterName":"cdnCacheSafe","filterValues":["false"]},
+            {"filterName":"channel","filterValues":["EXPLORE"]},
+            {"filterName":"datePickerType","filterValues":["calendar"]},
+            {"filterName":"flexibleTripLengths","filterValues":["one_week"]},
+            {"filterName":"itemsPerGrid","filterValues":["50"]},#if you read this, this is items returned number, this can bex exploited  ;)
+            {"filterName":"monthlyLength","filterValues":["3"]},
         {"filterName":"monthlyStartDate","filterValues":["2024-02-01"]},
-        {"filterName":"neLat","filterValues":[str(ne_lat)]},
-        {"filterName":"neLng","filterValues":[str(ne_long)]},
+            {"filterName":"neLat","filterValues":[str(ne_lat)]},
+            {"filterName":"neLng","filterValues":[str(ne_long)]},
         {"filterName":"placeId","filterValues":["ChIJpTeBx6wjq5oROJeXkPCSSSo"]},
-        {"filterName":"priceFilterInputType","filterValues":["0"]},
+            {"filterName":"priceFilterInputType","filterValues":["0"]},
         {"filterName":"query","filterValues":["Galapagos Island, Ecuador"]},
-        {"filterName":"screenSize","filterValues":["large"]},
-        {"filterName":"refinementPaths","filterValues":["/homes"]},
-        {"filterName":"searchByMap","filterValues":["true"]},
-        {"filterName":"swLat","filterValues":[str(sw_lat)]},
-        {"filterName":"swLng","filterValues":[str(sw_long)]},
-        {"filterName":"tabId","filterValues":["home_tab"]},
-        {"filterName":"version","filterValues":["1.8.3"]},
-        {"filterName":"zoomLevel","filterValues":[str(zoom_value)]},
-    ]
+            {"filterName":"screenSize","filterValues":["large"]},
+            {"filterName":"refinementPaths","filterValues":["/homes"]},
+            {"filterName":"searchByMap","filterValues":["true"]},
+            {"filterName":"swLat","filterValues":[str(sw_lat)]},
+            {"filterName":"swLng","filterValues":[str(sw_long)]},
+            {"filterName":"tabId","filterValues":["home_tab"]},
+            {"filterName":"version","filterValues":["1.8.3"]},
+            {"filterName":"zoomLevel","filterValues":[str(zoom_value)]},
+        ]
 
-    if check_in is not None and len(check_in) > 0 and check_out is not None and len(check_out) > 0:
-        check_in_date = datetime.strptime(check_in, "%Y-%m-%d")
-        check_out_date = datetime.strptime(check_out, "%Y-%m-%d")
+        if check_in is not None and len(check_in) > 0 and check_out is not None and len(check_out) > 0:
+            check_in_date = datetime.strptime(check_in, "%Y-%m-%d")
+            check_out_date = datetime.strptime(check_out, "%Y-%m-%d")
 
-        difference = check_out_date - check_in_date
-        days = difference.days
-        rawParams.extend([
-            {"filterName":"checkin","filterValues":[check_in]},
-            {"filterName":"checkout","filterValues":[check_out]},
-            {"filterName":"priceFilterNumNights","filterValues":[str(days)]},
-        ])
+            difference = check_out_date - check_in_date
+            days = difference.days
+            rawParams.extend([
+                {"filterName":"checkin","filterValues":[check_in]},
+                {"filterName":"checkout","filterValues":[check_out]},
+                {"filterName":"priceFilterNumNights","filterValues":[str(days)]},
+            ])
 
-    if place_type is not None and place_type in ("Private room","Entire home/apt"):
-        rawParams.append({"filterName":"room_types","filterValues": [place_type]})
-        rawParams.append({"filterName":"selected_filter_order","filterValues": ["room_types:"+place_type]})
+        if place_type is not None and place_type in ("Private room","Entire home/apt"):
+            rawParams.append({"filterName":"room_types","filterValues": [place_type]})
+            rawParams.append({"filterName":"selected_filter_order","filterValues": ["room_types:"+place_type]})
 
-    if price_min is not None and price_min > 0:
-        rawParams.append({"filterName":"price_min","filterValues": [str(price_min)]})
+        if price_min is not None and price_min > 0:
+            rawParams.append({"filterName":"price_min","filterValues": [str(price_min)]})
 
-    if price_max is not None and price_max > 0:
-        rawParams.append({"filterName":"price_max","filterValues": [str(price_max)]})
-        
-    # Add amenities filtering if provided
-    if amenities is not None and len(amenities) > 0:
-        # Add each amenity as a separate filter
-        amenity_str_values = [str(amenity_id) for amenity_id in amenities]
-        rawParams.append({"filterName":"amenities","filterValues": amenity_str_values})
-        
-        # Add selected filter order for each amenity
-        for amenity_id in amenities:
-            rawParams.append({"filterName":"selected_filter_order","filterValues": [f"amenities:{amenity_id}"]})
+        if price_max is not None and price_max > 0:
+            rawParams.append({"filterName":"price_max","filterValues": [str(price_max)]})
 
-    # Add free cancellation filtering if provided
-    if free_cancellation is not None and free_cancellation:
-        rawParams.append({"filterName":"flexible_cancellation","filterValues": ["true"]})
-        rawParams.append({"filterName":"selected_filter_order","filterValues": ["flexible_cancellation:true"]})
+        # Add amenities filtering if provided
+        if amenities is not None and len(amenities) > 0:
+            # Add each amenity as a separate filter
+            amenity_str_values = [str(amenity_id) for amenity_id in amenities]
+            rawParams.append({"filterName":"amenities","filterValues": amenity_str_values})
 
-    # Add guest filtering if provided
-    if adults is not None and adults > 0:
-        rawParams.append({"filterName":"adults","filterValues": [str(adults)]})
+            # Add selected filter order for each amenity
+            for amenity_id in amenities:
+                rawParams.append({"filterName":"selected_filter_order","filterValues": [f"amenities:{amenity_id}"]})
 
-    if children is not None and children > 0:
-        rawParams.append({"filterName":"children","filterValues": [str(children)]})
+        # Add free cancellation filtering if provided
+        if free_cancellation is not None and free_cancellation:
+            rawParams.append({"filterName":"flexible_cancellation","filterValues": ["true"]})
+            rawParams.append({"filterName":"selected_filter_order","filterValues": ["flexible_cancellation:true"]})
 
-    if infants is not None and infants > 0:
-        rawParams.append({"filterName":"infants","filterValues": [str(infants)]})
+        # Add guest filtering if provided
+        if adults is not None and adults > 0:
+            rawParams.append({"filterName":"adults","filterValues": [str(adults)]})
 
-    # Add property filtering if provided
-    if min_bedrooms is not None and min_bedrooms > 0:
-        rawParams.append({"filterName":"min_bedrooms","filterValues": [str(min_bedrooms)]})
-        rawParams.append({"filterName":"selected_filter_order","filterValues": [f"min_bedrooms:{min_bedrooms}"]})
+        if children is not None and children > 0:
+            rawParams.append({"filterName":"children","filterValues": [str(children)]})
 
-    if min_beds is not None and min_beds > 0:
-        rawParams.append({"filterName":"min_beds","filterValues": [str(min_beds)]})
-        rawParams.append({"filterName":"selected_filter_order","filterValues": [f"min_beds:{min_beds}"]})
+        if infants is not None and infants > 0:
+            rawParams.append({"filterName":"infants","filterValues": [str(infants)]})
 
-    if min_bathrooms is not None and min_bathrooms > 0:
-        rawParams.append({"filterName":"min_bathrooms","filterValues": [str(min_bathrooms)]})
-        rawParams.append({"filterName":"selected_filter_order","filterValues": [f"min_bathrooms:{min_bathrooms}"]})
+        # Add property filtering if provided
+        if min_bedrooms is not None and min_bedrooms > 0:
+            rawParams.append({"filterName":"min_bedrooms","filterValues": [str(min_bedrooms)]})
+            rawParams.append({"filterName":"selected_filter_order","filterValues": [f"min_bedrooms:{min_bedrooms}"]})
+
+        if min_beds is not None and min_beds > 0:
+            rawParams.append({"filterName":"min_beds","filterValues": [str(min_beds)]})
+            rawParams.append({"filterName":"selected_filter_order","filterValues": [f"min_beds:{min_beds}"]})
+
+        if min_bathrooms is not None and min_bathrooms > 0:
+            rawParams.append({"filterName":"min_bathrooms","filterValues": [str(min_bathrooms)]})
+            rawParams.append({"filterName":"selected_filter_order","filterValues": [f"min_bathrooms:{min_bathrooms}"]})
 
     inputData = {
         "operationName":"StaysSearch",

--- a/src/pyairbnb/start.py
+++ b/src/pyairbnb/start.py
@@ -208,74 +208,37 @@ def search_experience_by_taking_the_first_inputs_i_dont_care(user_input_text: st
 
 def search_all_from_url(url: str, currency: str = "USD", language: str = "en", proxy_url: str = "", hash: str = ""):
     """
-    Wrapper that parses an Airbnb search URL and delegates to search_all.
+    Parses an Airbnb search URL and forwards all recognizable filters to
+    Airbnb's StaysSearch API. The URL is the source of truth: any URL
+    parameter (known or unknown) is passed through.
     """
-    from urllib.parse import urlparse, parse_qs
-    parsed = urlparse(url)
-    qs = parse_qs(parsed.query)
-
-    # Extract required parameters
-    check_in = qs.get("checkin", [None])[0]
-    check_out = qs.get("checkout", [None])[0]
-    ne_lat = float(qs.get("ne_lat", [0])[0])
-    ne_long = float(qs.get("ne_lng", [0])[0])
-    sw_lat = float(qs.get("sw_lat", [0])[0])
-    sw_long = float(qs.get("sw_lng", [0])[0])
-
-    # Determine zoom value
-    zoom_str = qs.get("zoom_level", qs.get("zoom", [0]))[0]
-    zoom_value = int(float(zoom_str))
-
-    # Price filters
-    price_min = int(qs.get("price_min", [0])[0])
-    price_max = int(qs.get("price_max", [0])[0])
-
-    # Place type filter
-    place_type = qs.get("room_types[]", [None])[0]
-
-    # Amenities list
-    amenities = []
-    for a in qs.get("amenities[]", []):
-        try:
-            amenities.append(int(a))
-        except ValueError:
-            continue
-
-    # Free cancellation filter
-    free_cancellation = qs.get("flexible_cancellation", ["false"])[0].lower() == "true"
-
-    # Guest filters
-    adults = int(qs.get("adults", [0])[0])
-    children = int(qs.get("children", [0])[0])
-    infants = int(qs.get("infants", [0])[0])
-
-    # Property filters
-    min_bedrooms = int(qs.get("min_bedrooms", [0])[0])
-    min_beds = int(qs.get("min_beds", [0])[0])
-    min_bathrooms = int(qs.get("min_bathrooms", [0])[0])
-
-    # Delegate to existing search_all
-    return search_all(
-        check_in=check_in,
-        check_out=check_out,
-        ne_lat=ne_lat,
-        ne_long=ne_long,
-        sw_lat=sw_lat,
-        sw_long=sw_long,
-        zoom_value=zoom_value,
-        price_min=price_min,
-        price_max=price_max,
-        place_type=place_type,
-        amenities=amenities,
-        free_cancellation=free_cancellation,
-        adults=adults,
-        children=children,
-        infants=infants,
-        min_bedrooms=min_bedrooms,
-        min_beds=min_beds,
-        min_bathrooms=min_bathrooms,
-        currency=currency,
-        language=language,
-        proxy_url=proxy_url,
-        hash=hash
-    )
+    raw_params = search.url_to_raw_params(url)
+    api_key = api.get(proxy_url)
+    all_results = []
+    cursor = ""
+    # search.get's structured-args are ignored when raw_params is supplied,
+    # but they're still required by the signature. Pass them by name so this
+    # call doesn't break if their positional order ever changes.
+    call_kwargs = {
+        "currency": currency, "language": language,
+        "proxy_url": proxy_url, "hash": hash,
+        "raw_params": raw_params,
+        "check_in": None, "check_out": None,
+        "ne_lat": 0, "ne_long": 0, "sw_lat": 0, "sw_long": 0,
+        "zoom_value": 0, "place_type": "",
+        "price_min": 0, "price_max": 0, "amenities": [],
+        "free_cancellation": False,
+        "adults": 0, "children": 0, "infants": 0,
+        "min_bedrooms": 0, "min_beds": 0, "min_bathrooms": 0,
+    }
+    while True:
+        results_raw = search.get(api_key=api_key, cursor=cursor, **call_kwargs)
+        paginationInfo = utils.get_nested_value(
+            results_raw, "data.presentation.staysSearch.results.paginationInfo", {}
+        )
+        results = standardize.from_search(results_raw)
+        all_results.extend(results)
+        if not results or not paginationInfo.get("nextPageCursor"):
+            break
+        cursor = paginationInfo["nextPageCursor"]
+    return all_results


### PR DESCRIPTION
## Summary

- `search_all_from_url` now forwards every URL query param to Airbnb instead of dropping all but ~15 named ones. URLs with `place_id`, `query`, `category_tag`, `flexible_trip_lengths`, `selected_filter_order[]`, etc. now actually take effect.
- New `search.url_to_raw_params(url)` does the URL → rawParams conversion: snake→camelCase by default, with a small set of snake-only exceptions for filters Airbnb's API expects in snake_case (`price_min`, `amenities`, `room_types`, ...).
- `search.get` gains an optional `raw_params` kwarg used by `search_all_from_url` to bypass the structured-args builder. `search_all` / `search_first_page` are unchanged.