### PR TITLE
Fix decimal cents dropped into currency field in parse_price_symbol

### DIFF
--- a/src/pyairbnb/utils.py
+++ b/src/pyairbnb/utils.py
@@ -7,7 +7,7 @@ Timeout: TypeAlias = int | float | tuple[int | float, int | float] | None
 DEFAULT_TIMEOUT: Timeout = 60
 
 regex_space = re.compile(r'[\s ]+')
-regx_price = re.compile(r'\d+')
+regx_price = re.compile(r'\d+(?:\.\d+)?')
 
 def remove_space(value:str):
     return regex_space.sub(' ', value.strip())


### PR DESCRIPTION
## Fix decimal cents being dropped into the currency field in `parse_price_symbol`

### Problem

`utils.parse_price_symbol()` truncates the decimal part of any price that has
cents, and the truncated digits end up appended to the currency symbol instead.

Repro:

```python
>>> from pyairbnb.utils import parse_price_symbol
>>> parse_price_symbol("€3,310.39")
(3310.0, '€.39')
```

Expected `(3310.39, '€')`. I ran into this while parsing the "Average monthly
price" line from a monthly-stay listing's price breakdown (`"€3,310.39"`) —
the amount silently lost its cents and the currency symbol came out as
`"€.39"`, which then breaks anything downstream that expects `price_currency`
to actually be a currency symbol.

The same truncation affects every price string that has a fractional part,
e.g. `"-€900.00"` (a monthly-stay discount line) comes back as
`(-900.0, '€.00')` instead of `(-900.0, '€')`.

### Root cause

`utils.py` line 10:

```python
regx_price = re.compile(r'\d+')
```

This only matches a run of digits, so on `"3310.39"` it stops at the dot and
only captures `"3310"`. The remaining `".39"` isn't consumed by the match, so
it survives the `price_raw.replace(price_number, "")` step a few lines later
and gets folded into `price_currency`.

### Fix

Make the regex optionally consume a decimal part:

```python
regx_price = re.compile(r'\d+(?:\.\d+)?')
```

That's the only change. I double-checked that the existing comma-stripping
(`price_raw.replace(",", "")`, done before the regex runs) and the `-`
handling (`price_raw.startswith("-")`, checked after replacing the currency
symbol) both still work correctly with the wider match — see the matrix
below.

### Note on localized number formats

Some locales format prices with `.` as the thousands separator and `,` as
the decimal separator (e.g. `"1.234,56 €"`). I looked for this shape across a
few hundred real price strings pulled from search results and PDP price
breakdowns (various currencies, always requested through the normal search /
price endpoints) and never saw it — every value observed uses `,` for
thousands and `.` for decimals regardless of currency symbol (`"€3,310.39"`,
`"€15,000"`, etc.), which matches what `parse_price_symbol` already assumes
via the unconditional comma-strip. So I didn't touch that path — it doesn't
seem to be something the API actually returns, and "fixing" it without a
real example to verify against would just be guessing. Flagging it here in
case anyone has a counter-example.

### Verification matrix

Ran `parse_price_symbol()` before/after the regex change on the shapes that
actually occur in price payloads, plus a couple of edge cases:

| input | before (buggy) | after (fixed) |
|---|---|---|
| `"€2,467"` | `(2467.0, '€')` | `(2467.0, '€')` |
| `"€3,310.39"` | `(3310.0, '€.39')` | `(3310.39, '€')` |
| `"$1,234.56"` | `(1234.0, '$.56')` | `(1234.56, '$')` |
| `"-€900.00"` | `(-900.0, '€.00')` | `(-900.0, '€')` |
| `"-€900"` | `(-900.0, '€')` | `(-900.0, '€')` |
| `"2,467.89"` (no symbol) | `(2467.0, '.89')` | `(2467.89, '')` |
| `"56"` (no symbol, integer) | `(56.0, '')` | `(56.0, '')` |
| `"€56.00"` | `(56.0, '€.00')` | `(56.0, '€')` |
| `"€15,000"` | `(15000.0, '€')` | `(15000.0, '€')` |

All non-decimal cases are unaffected; all decimal cases now round-trip
correctly with the currency symbol left intact.

### Tests

I didn't find a `tests/` folder or any test runner config in the repo, and
`test.py` at the root is a live-network usage example rather than a unit
test, so I didn't see an obvious place to bolt a regression test onto. Happy
to add one in whatever style/location you'd prefer if you point me at it —
otherwise the matrix above is what I verified locally against both the
unpatched and patched module.
