### PR TITLE
fix: resolves issues when api key is not found on airbnb homepage

### DIFF
--- a/src/pyairbnb/api.py
+++ b/src/pyairbnb/api.py
@@ -27,10 +27,34 @@ def get(proxy_url: str, timeout: Timeout = DEFAULT_TIMEOUT) -> str:
         proxies = {"http": proxy_url, "https": proxy_url}
 
     response = requests.get(ep, headers=headers, proxies=proxies, timeout=timeout)
-    response.raise_for_status() 
+    response.raise_for_status()
 
     body = response.text
-    api_key = regx_api_key.search(body).group()
+    api_key_match = regx_api_key.search(body)
+
+    if not api_key_match:
+        # Airbnb may return a domain-switch landing page instead of the actual homepage.
+        handoff_match = re.search(r'<form[^>]+action="([^"]+)"', body)
+        payload_match = re.search(r'<input[^>]+name="payload"[^>]+value="([^"]+)"', body)
+
+        if handoff_match and payload_match:
+            handoff_url = handoff_match.group(1)
+            payload_value = payload_match.group(1)
+            response = requests.post(
+                handoff_url,
+                data={"version": "1", "payload": payload_value},
+                headers=headers,
+                proxies=proxies,
+                timeout=60,
+            )
+            response.raise_for_status()
+            body = response.text
+            api_key_match = regx_api_key.search(body)
+
+    if not api_key_match:
+        raise Exception("Could not parse Airbnb API key from the homepage response.")
+
+    api_key = api_key_match.group()
     api_key = api_key.replace('"api_config":{"key":"', '')
     api_key = api_key.replace('"', "")
     return api_key


### PR DESCRIPTION
Prevents pyairbnb.api.get() from crashing with AttributeError when Airbnb returns a domain-switch landing page. The change attempts the existing api_config regex, and if not found, follows the handoff flow (POSTing the hidden payload) and re-parses the returned HTML to extract the API key. If extraction still fails, a descriptive exception is raised.

Why this change: Airbnb sometimes returns a POST-based domain-switch landing page (redirect to regional domain) that does not include the expected api_config JSON fragment. The previous code called .group() on the regex match result which caused AttributeError when the match was None.

Testing steps: 
Manually verified that https://www.airbnb.co.in contains api_config and the new path extracts the key.
Ran the local script with the virtualenv interpreter and observed the earlier exception no longer occurs (manual verification).